### PR TITLE
app: view: Try to fix bad Chinese characters display

### DIFF
--- a/lib/core/app/app_view.dart
+++ b/lib/core/app/app_view.dart
@@ -30,8 +30,18 @@ class AppView extends HookConsumerWidget with PresLogger {
     return MaterialApp.router(
       routerConfig: router,
       locale: locale,
-      supportedLocales: AppLocaleUtils.supportedLocales,
-      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      supportedLocales: const [
+        Locale("en", "US"),
+        Locale("fa", "IR"),
+        Locale("ru", "RU"),
+        Locale("tr", "TR"),
+        Locale("zh", "CN"),
+      ],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       debugShowCheckedModeBanner: false,
       themeMode: theme.mode.flutterThemeMode,
       theme: theme.light(),


### PR DESCRIPTION
Flutter 3 has some problems with Chinese character render on Windows, the following is a simple fix.

Before:

![before](https://github.com/hiddify/hiddify-next/assets/30405429/3b74bb52-480b-4e97-b304-7a25a92a1bab)

After fix:

![afterfix](https://github.com/hiddify/hiddify-next/assets/30405429/b8d09a6c-62df-4db4-9dfe-b4bf954230c9)

