### PR TITLE
[fix]: SettingsPickerDialog pop exception

### DIFF
--- a/lib/features/settings/widgets/settings_input_dialog.dart
+++ b/lib/features/settings/widgets/settings_input_dialog.dart
@@ -155,7 +155,9 @@ class SettingsPickerDialog<T> extends HookConsumerWidget with PresLogger {
                 title: Text(getTitle(e)),
                 value: e,
                 groupValue: selected,
-                onChanged: (value) => context.pop(e),
+                onChanged: (value) async {
+                  await Navigator.of(context).maybePop(e);
+                },
               ),
             )
             .toList(),


### PR DESCRIPTION
fix SettingsPickerDialog pop exception

when `onChanged: (value) => context.pop(e)`:
![pop-bug](https://github.com/hiddify/hiddify-next/assets/31154238/65760e0a-99cb-4dc9-a191-304e0ffba3a6)

fix to `Navigator.of(context).maybePop(e)`:
![pop-fix](https://github.com/hiddify/hiddify-next/assets/31154238/3b6b7035-defd-4cbb-abd7-83fcfc504be4)
