### PR TITLE
add aur-x64 bin package's link for Arch/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Vless, Vmess, Reality, TUIC, Hysteria, Wireguard, SSH etc.
             <td>
                 <a href="https://github.com/hiddify/hiddify-next/releases/latest/download/Hiddify-Linux-x64.AppImage"><img src="https://img.shields.io/badge/AppImage-x64-f84e29.svg?logo=linux"> </a><br>
                 <a href="https://github.com/hiddify/hiddify-next/releases/latest/download/Hiddify-Debian-x64.deb"><img src="https://img.shields.io/badge/DebPackage-x64-FF9966.svg?logo=debian"> </a><br>
-                <a href="https://github.com/hiddify/hiddify-next/releases/latest/download/Hiddify-rpm-x64.rpm"><img src="https://img.shields.io/badge/RpmPackage-x64-F1B42F.svg?logo=redhat"> </a>
+                <a href="https://github.com/hiddify/hiddify-next/releases/latest/download/Hiddify-rpm-x64.rpm"><img src="https://img.shields.io/badge/RpmPackage-x64-F1B42F.svg?logo=redhat"> </a><br>
+                <a href="https://aur.archlinux.org/packages/hiddify-next-aur-x64"><img src="https://img.shields.io/badge/AUR%20package-x64-3b9bf5.svg?logo=archlinux"> </a>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
A package tailored for hiddify was created and made available in Arch Linux's user repository. While I'm not in charge of maintaining that package, I included information about it in the README. This way, users of Arch Linux (and its derivatives) can easily install it ( with ``` yay -S hiddify-next-aur-x64 ``` ) instead of using the AppImage.