### PR TITLE
Fix URLTest Fails

### DIFF
--- a/lib/features/config_option/data/config_option_repository.dart
+++ b/lib/features/config_option/data/config_option_repository.dart
@@ -102,7 +102,7 @@ abstract class ConfigOptions {
 
   static final connectionTestUrl = PreferencesNotifier.create<String, String>(
     "connection-test-url",
-    "http://cp.cloudflare.com/",
+    "https://www.gstatic.com/generate_204",
     validator: (value) => value.isNotBlank && isUrl(value),
   );
 


### PR DESCRIPTION
This PR will solve problem of users which have many configs and all of those configs' outbound have same IP
Because `cp.cloudflare.com` blocks the outbound ip if they receive many request at same time, but gstatic will not block
And HTTPS is more accurate (HTTP url gives false url-test result)