### PR TITLE
Fix typo in stats_repository.dart

### DIFF
--- a/lib/features/stats/data/stats_repository.dart
+++ b/lib/features/stats/data/stats_repository.dart
@@ -24,7 +24,7 @@ class StatsRepositoryImpl
           (event) => StatsEntity(
             uplink: event.uplink,
             downlink: event.downlink,
-            uplinkTotal: event.downlink,
+            uplinkTotal: event.uplinkTotal,
             downlinkTotal: event.downlinkTotal,
           ),
         )


### PR DESCRIPTION
I don't write dart, so I do not know if it is wrong.
I just find this typo while using the application, as total uplink is equal downlink on UI.
I do not know if event.uplinkTotal real exist, but I think there should be one like this.