### PR TITLE
Fix iOS Crash Due to Outdated change_config_options Method Name

### DIFF
--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -10,27 +10,27 @@ import Combine
 import Libcore
 
 public class MethodHandler: NSObject, FlutterPlugin {
-    
+
     private var cancelBag: Set<AnyCancellable> = []
-    
+
     public static let name = "\(Bundle.main.serviceIdentifier)/method"
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: Self.name, binaryMessenger: registrar.messenger())
         let instance = MethodHandler()
         registrar.addMethodCallDelegate(instance, channel: channel)
         instance.channel = channel
     }
-    
+
     private var channel: FlutterMethodChannel?
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         @Sendable func mainResult(_ res: Any?) async -> Void {
             await MainActor.run {
                 result(res)
             }
         }
-        
+
         switch call.method {
         case "parse_config":
             guard
@@ -49,7 +49,7 @@ public class MethodHandler: NSObject, FlutterPlugin {
                 return
             }
             result("")
-        case "change_config_options":
+        case "change_hiddify_options":
             guard let options = call.arguments as? String else {
                 result(FlutterError(code: "INVALID_ARGS", message: nil, details: nil))
                 return
@@ -186,7 +186,7 @@ public class MethodHandler: NSObject, FlutterPlugin {
             result(FlutterMethodNotImplemented)
         }
     }
-    
+
     private func waitForStop() -> Future<Void, Never> {
         return Future { promise in
             var cancellable: AnyCancellable? = nil


### PR DESCRIPTION
This PR resolves an issue causing a crash on iOS due to the change_config_options method name not being updated. The outdated method name has now been corrected to ensure compatibility and prevent runtime errors.