### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       draftBuildCode: ${{ steps.draftBuildCode.outputs.datetime }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2.16.0 #issue with 2.13
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Import Apple Codesign Certificates
         if: ${{ inputs.upload-artifact && startsWith(matrix.os,'macos') }}
@@ -168,7 +168,7 @@ jobs:
       
       - name: Setup Java
         if: startsWith(matrix.platform,'android')
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
@@ -185,7 +185,7 @@ jobs:
         uses: android-actions/setup-android@v3
         if: startsWith(matrix.platform,'android')
       # - name: Cache Android SDK
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v5
       #   if: startsWith(matrix.platform,'android')
       #   with:
       #     path: |
@@ -194,7 +194,7 @@ jobs:
       #     restore-keys: |
       #       android-sdk-${{ runner.os }}-      
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: startsWith(matrix.platform,'android')
 
         with:
@@ -345,7 +345,7 @@ jobs:
 
       - name: Upload Artifact
         if: env.UPLOAD_ARTIFACT == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{matrix.platform}}
           path: ./out
@@ -363,13 +363,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # by default, it uses a depth of 1
           # this fetches all history so that we can read each commit
           fetch-depth: 0
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           merge-multiple: true
           pattern: "*"
@@ -429,10 +429,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           merge-multiple: true
           pattern: "*"
@@ -482,7 +482,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           merge-multiple: true
           pattern: "*ios*"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # stale-issue-message: 'With the release of v4.0.0 (pre-release), most reported issues have been fixed. We’re closing all current issues to start fresh.If you’re still experiencing the problem, please open a new issue and let us know.'
           days-before-stale: 30


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | build.yml |
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | build.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | build.yml |
| `actions/stale` | [`v9`](https://github.com/actions/stale/releases/tag/v9) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) | stale.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/stale** (v9 → v10): Major version upgrade — review the [release notes](https://github.com/actions/stale/releases) for breaking changes
- **actions/checkout** (v3 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-java** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/actions/setup-java/releases) for breaking changes
- **actions/cache** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/actions/cache/releases) for breaking changes
- **actions/upload-artifact** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/download-artifact** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/download-artifact/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
