### PR TITLE
fix infiniteTrafficThreshold value

### DIFF
--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -28,7 +28,7 @@ import 'package:meta/meta.dart';
 /// - local: fallback to protocol, extracted from content by protocol()
 
 class ProfileParser {
-  static const infiniteTrafficThreshold = 92233720368;
+  static const infiniteTrafficThreshold = 9223372036854775807;
   static const infiniteTimeThreshold = 92233720368;
   static const allowedOverrideConfigs = [
     'connection-test-url',


### PR DESCRIPTION
In new version Hiddify, when subscription-Userinfo total=0 is treated as quota exceeded instead of unlimited, because unlimited in code was 92233720368 bytes (approximately 85gb), I raised unlimited traffic const to max long value.
Issue: https://github.com/hiddify/hiddify-app/issues/1974