### PR TITLE
fix(profile): align infinite traffic threshold with unlimited display check

### DIFF
--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -28,7 +28,7 @@ import 'package:meta/meta.dart';
 /// - local: fallback to protocol, extracted from content by protocol()
 
 class ProfileParser {
-  static const infiniteTrafficThreshold = 920_233_720_368;
+  static const infiniteTrafficThreshold = 10_995_116_277_760;
   static const infiniteTimeThreshold = 92_233_720_368;
   static const allowedOverrideConfigs = [
     'connection-test-url',

--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -13,6 +13,7 @@ import 'package:hiddify/core/router/dialog/dialog_notifier.dart';
 import 'package:hiddify/core/router/go_router/helper/active_breakpoint_notifier.dart';
 import 'package:hiddify/core/widget/adaptive_icon.dart';
 import 'package:hiddify/core/widget/adaptive_menu.dart';
+import 'package:hiddify/features/profile/data/profile_parser.dart';
 import 'package:hiddify/features/profile/model/profile_entity.dart';
 import 'package:hiddify/features/profile/notifier/profile_notifier.dart';
 import 'package:hiddify/features/profile/overview/profiles_notifier.dart';
@@ -344,9 +345,7 @@ class ProfileSubscriptionInfo extends HookConsumerWidget {
           textDirection: TextDirection.ltr,
           child: Flexible(
             child: Text(
-              subInfo.total >
-                      10 *
-                          1099511627776 //10TB
+              subInfo.total > ProfileParser.infiniteTrafficThreshold
                   ? "∞ GiB"
                   : subInfo.consumption.sizeOf(subInfo.total),
               semanticsLabel: t.components.subscriptionInfo.remainingTrafficSemanticLabel(
@@ -392,9 +391,7 @@ class NewTrafficSubscriptionInfo extends HookConsumerWidget {
             Directionality(
               textDirection: TextDirection.ltr,
               child: Text(
-                subInfo.total >
-                        10 *
-                            1099511627776 //10TB
+                subInfo.total > ProfileParser.infiniteTrafficThreshold
                     ? "∞ GiB"
                     : subInfo.consumption.sizeOf(subInfo.total),
                 semanticsLabel: t.components.subscriptionInfo.remainingTrafficSemanticLabel(
@@ -497,9 +494,7 @@ class NewDayTrafficSubscriptionInfo extends HookConsumerWidget {
         Directionality(
           textDirection: TextDirection.ltr,
           child: Text(
-            subInfo.total >
-                    10 *
-                        1099511627776 //10TB
+            subInfo.total > ProfileParser.infiniteTrafficThreshold
                 ? "∞ GiB"
                 : subInfo.consumption.sizeOf(subInfo.total),
             semanticsLabel: t.components.subscriptionInfo.remainingTrafficSemanticLabel(


### PR DESCRIPTION
When a subscription sends `total=0` (meaning unlimited traffic), the parser maps it to `infiniteTrafficThreshold + 1` (~857 GiB). But the UI only shows `∞ GiB` when `total > 10 TiB`. Since 857 GiB < 10 TiB, the app incorrectly displays a finite quota and `Quota exceeded` warnings.

1) Set `infiniteTrafficThreshold` value from 857 GiB to 10 TiB to match the display threshold
2) Replaced hardcoded magic number `10 * 1099511627776` with `ProfileParser.infiniteTrafficThreshold` for a single source of truth

Fixes https://github.com/hiddify/hiddify-app/issues/1974 