### PR TITLE
Added a Google Video link for connection testing

### DIFF
--- a/lib/features/settings/data/config_option_repository.dart
+++ b/lib/features/settings/data/config_option_repository.dart
@@ -143,6 +143,7 @@ abstract class ConfigOptions {
       "http://connectivitycheck.gstatic.com/generate_204",
       "http://www.gstatic.com/generate_204",
       "https://www.gstatic.com/generate_204",
+      "https://redirector.googlevideo.com/generate_204",
       "http://cp.cloudflare.com",
       "http://kernel.org",
       "http://detectportal.firefox.com",


### PR DESCRIPTION
Some free servers block access to Google’s video servers. This will be helpful for those using a VPN in countries where YouTube is banned.