### PR TITLE
Fix app freeze on the splash screen in Android 16+

### DIFF
--- a/lib/core/directories/directories_provider.dart
+++ b/lib/core/directories/directories_provider.dart
@@ -37,7 +37,7 @@ class AppDirectories extends _$AppDirectories with InfraLogger {
       dirs = (baseDir: portableDir, workingDir: portableDir, tempDir: await getTemporaryDirectory());
     } else {
       final baseDir = await getApplicationSupportDirectory();
-      final workingDir = Platform.isAndroid ? await getExternalStorageDirectory() : baseDir;
+      final workingDir = Platform.isAndroid ? await _getAndroidWorkingDirectory() : baseDir;
       final tempDir = await getTemporaryDirectory();
       dirs = (baseDir: baseDir, workingDir: workingDir!, tempDir: tempDir);
     }
@@ -50,6 +50,17 @@ class AppDirectories extends _$AppDirectories with InfraLogger {
     }
 
     return dirs;
+  }
+
+  static Future<Directory> _getAndroidWorkingDirectory() async {
+    try {
+      final extDir = await getExternalStorageDirectory();
+      if (extDir == null) return getApplicationDocumentsDirectory();
+      if (extDir.existsSync()) return extDir;
+      await extDir.create(recursive: true);
+      return extDir;
+    } catch (_) {}
+    return getApplicationDocumentsDirectory();
   }
 
   static Future<Directory> getDatabaseDirectory() async {


### PR DESCRIPTION
On Android 16, the app freezes on the splash screen, and the following logs are shown in Logcat:

```
Failed to ensure /storage/emulated/0/Android/data/app.hiddify.com/files
java.lang.IllegalStateException: Failed to prepare /storage/emulated/0/Android/data/app.hiddify.com/files
    at android.os.Parcel.createExceptionOrNull(Parcel.java:3381)
    at android.os.Parcel.createException(Parcel.java:3357)
    at android.os.Parcel.readException(Parcel.java:3340)
    at android.os.Parcel.readException(Parcel.java:3282)
    at android.os.storage.IStorageManager$Stub$Proxy.mkdirs(IStorageManager.java:1305)
    at android.os.storage.StorageManager.mkdirs(StorageManager.java:1421)
    at android.app.ContextImpl.ensureExternalDirsExistOrFilter(ContextImpl.java:3937)
    at android.app.ContextImpl.getExternalFilesDirs(ContextImpl.java:935)
    at android.app.ContextImpl.getExternalFilesDir(ContextImpl.java:924)
    at android.content.ContextWrapper.getExternalFilesDir(ContextWrapper.java:308)
    at io.flutter.plugins.pathprovider.PathProviderPlugin.getExternalStoragePath(PathProviderPlugin.java:68)
    at io.flutter.plugins.pathprovider.Messages$PathProviderApi.lambda$setUp$4(Messages.java:261)
    at io.flutter.plugins.pathprovider.Messages$PathProviderApi$$ExternalSyntheticLambda4.onMessage(D8$$SyntheticClass:0)
    at io.flutter.plugin.common.BasicMessageChannel$IncomingMessageHandler.onMessage(BasicMessageChannel.java:261)
    at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:286)
    at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:313)
    at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
    at io.flutter.embedding.engine.dart.DartMessenger$SerialTaskQueue.flush(DartMessenger.java:170)
    at io.flutter.embedding.engine.dart.DartMessenger$SerialTaskQueue.$r8$lambda$cTZ9WyQfMSOYykqHSDioeEg9Yqc(Unknown Source:0)
    at io.flutter.embedding.engine.dart.DartMessenger$SerialTaskQueue$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)

2026-03-31 20:03:47.921 30398-30398 flutter                 app.hiddify.com                      I  20:03:47.921277 [ERROR]    [bootstrap] [directories] error initializing
2026-03-31 20:03:47.921 30398-30398 flutter                 app.hiddify.com                      I  #0      _checkForErrorResponse (dart:io/common.dart:58:9)
#1      _Directory.create.<anonymous closure> (dart:io/directory_impl.dart:121:9)
<asynchronous suspension>
#2      _Directory.create.<anonymous closure>.<anonymous closure> (dart:io/directory_impl.dart:109:54)
<asynchronous suspension>
#3      AppDirectories.build (package:hiddify/core/directories/directories_provider.dart:49:7)
<asynchronous suspension>
#4      FutureHandlerProviderElementMixin.handleFuture.<anonymous closure>.<anonymous closure> (package:riverpod/src/async_notifier/base.dart:355:9)
<asynchronous suspension>
2026-03-31 20:03:47.924 30398-30398 flutter                 app.hiddify.com                      I  20:03:47.924212 [ERROR]    [app] PlatformDispatcherError: PathAccessException: Creation failed, path = '/storage/emulated/0/Android/data/app.hiddify.com' (OS Error: Permission denied, errno = 13)
2026-03-31 20:03:47.924 30398-30398 flutter                 app.hiddify.com                      I  #0      _checkForErrorResponse (dart:io/common.dart:58:9)
#1      _Directory.create.<anonymous closure> (dart:io/directory_impl.dart:121:9)
<asynchronous suspension>
#2      _Directory.create.<anonymous closure>.<anonymous closure> (dart:io/directory_impl.dart:109:54)
<asynchronous suspension>
#3      AppDirectories.build (package:hiddify/core/directories/directories_provider.dart:49:7)
<asynchronous suspension>
#4      FutureHandlerProviderElementMixin.handleFuture.<anonymous closure>.<anonymous closure> (package:riverpod/src/async_notifier/base.dart:355:9)
<asynchronous suspension>
```

That's because in Android 16+, [`getExternalStorageDirectory`](https://pub.dev/documentation/path_provider/latest/path_provider/getExternalStorageDirectory.html) requires `MANAGE_EXTERNAL_STORAGE` permission, which has security risks. As a fallback, [`getApplicationDocumentsDirectory `](https://pub.dev/documentation/path_provider/latest/path_provider/getApplicationDocumentsDirectory.html) can be used. This PR adds `getApplicationDocumentsDirectory` as a fallback for `getApplicationDocumentsDirectory`, which solves the app start problem on Android 16.

The only drawback of using `getApplicationDocumentsDirectory` is that when the app is uninstalled, the data is deleted, but this only affects users with Android 16+.

Tested on Xiaomi Redmi Note 9 Pro (miatoll)

Closes #2092.