### PR TITLE
feat: support new-domain header in subscription responses

### DIFF
--- a/lib/features/profile/data/profile_data_mapper.dart
+++ b/lib/features/profile/data/profile_data_mapper.dart
@@ -39,6 +39,7 @@ extension ProfileEntityMapper on ProfileEntity {
   ProfileEntriesCompanion toUpdateEntry() => map(
     remote: (rp) => ProfileEntriesCompanion(
       name: Value(rp.name),
+      url: Value(rp.url),
       lastUpdate: Value(rp.lastUpdate),
       updateInterval: Value(rp.options?.updateInterval),
       populatedHeaders: Value(jsonEncode(rp.populatedHeaders)),

--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -87,9 +87,7 @@ class ProfileParser {
       }
     }
 
-    return port != null
-        ? uri.replace(host: host, port: port).toString()
-        : uri.replace(host: host).toString();
+    return uri.replace(host: host, port: port ?? 0).toString();
   }
 
   final Ref _ref;

--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -50,7 +50,9 @@ class ProfileParser {
   ];
 
   // Resolves `new-domain` from response headers or subscription body content.
-  // Replaces only the host portion of [url], preserving path, query, and fragment.
+  // Replaces the host of [url] and the port if the new value includes one.
+  // If no port is given in new-domain, the original URL's port is preserved.
+  // Accepts: "example.com", "example.com:8080", "1.2.3.4", "1.2.3.4:8080", "[::1]", "[::1]:8080".
   static String resolveNewDomain(String url, String content, Map<String, dynamic> remoteHeaders) {
     String? newDomain = remoteHeaders['new-domain']?.toString().trim();
     if (newDomain == null || newDomain.isEmpty) {
@@ -59,7 +61,35 @@ class ProfileParser {
     if (newDomain == null || newDomain.isEmpty) return url;
     final uri = Uri.tryParse(url);
     if (uri == null) return url;
-    return uri.replace(host: newDomain).toString();
+
+    String host;
+    int? port;
+
+    if (newDomain.startsWith('[')) {
+      // IPv6: "[::1]" or "[::1]:8080"
+      final closingBracket = newDomain.indexOf(']');
+      host = newDomain.substring(0, closingBracket + 1);
+      if (closingBracket + 1 < newDomain.length && newDomain[closingBracket + 1] == ':') {
+        port = int.tryParse(newDomain.substring(closingBracket + 2));
+      }
+    } else {
+      final colonIndex = newDomain.lastIndexOf(':');
+      if (colonIndex != -1) {
+        final maybePort = int.tryParse(newDomain.substring(colonIndex + 1));
+        if (maybePort != null) {
+          host = newDomain.substring(0, colonIndex);
+          port = maybePort;
+        } else {
+          host = newDomain;
+        }
+      } else {
+        host = newDomain;
+      }
+    }
+
+    return port != null
+        ? uri.replace(host: host, port: port).toString()
+        : uri.replace(host: host).toString();
   }
 
   final Ref _ref;

--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -49,6 +49,19 @@ class ProfileParser {
     'enable-fragment',
   ];
 
+  // Resolves `new-domain` from response headers or subscription body content.
+  // Replaces only the host portion of [url], preserving path, query, and fragment.
+  static String resolveNewDomain(String url, String content, Map<String, dynamic> remoteHeaders) {
+    String? newDomain = remoteHeaders['new-domain']?.toString().trim();
+    if (newDomain == null || newDomain.isEmpty) {
+      newDomain = _parseHeadersFromContent(content)['new-domain']?.toString().trim();
+    }
+    if (newDomain == null || newDomain.isEmpty) return url;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return url;
+    return uri.replace(host: newDomain).toString();
+  }
+
   final Ref _ref;
   final DioHttpClient _httpClient;
 
@@ -92,25 +105,28 @@ class ProfileParser {
     required UserOverride? userOverride,
     CancelToken? cancelToken,
   }) => _downloadProfile(url, tempFilePath, cancelToken).flatMap(
-    (remoteHeaders) =>
-        TaskEither.fromEither(
-          populateHeaders(content: File(tempFilePath).readAsStringSync(), remoteHeaders: remoteHeaders),
-        ).flatMap(
-          (populatedHeaders) => TaskEither.fromEither(
-            parse(
-              tempFilePath: tempFilePath,
-              profile: ProfileEntity.remote(
-                id: id,
-                active: true,
-                name: '',
-                url: url,
-                lastUpdate: DateTime.now(),
-                userOverride: userOverride,
-                populatedHeaders: populatedHeaders,
-              ),
-            ).flatMap((profEntity) => Either.tryCatch(() => profEntity.toInsertEntry(), ProfileFailure.unexpected)),
-          ),
+    (remoteHeaders) {
+      final content = File(tempFilePath).readAsStringSync();
+      final resolvedUrl = resolveNewDomain(url, content, remoteHeaders);
+      return TaskEither.fromEither(
+        populateHeaders(content: content, remoteHeaders: remoteHeaders),
+      ).flatMap(
+        (populatedHeaders) => TaskEither.fromEither(
+          parse(
+            tempFilePath: tempFilePath,
+            profile: ProfileEntity.remote(
+              id: id,
+              active: true,
+              name: '',
+              url: resolvedUrl,
+              lastUpdate: DateTime.now(),
+              userOverride: userOverride,
+              populatedHeaders: populatedHeaders,
+            ),
+          ).flatMap((profEntity) => Either.tryCatch(() => profEntity.toInsertEntry(), ProfileFailure.unexpected)),
         ),
+      );
+    },
   );
 
   TaskEither<ProfileFailure, ProfileEntriesCompanion> updateRemote({
@@ -118,17 +134,20 @@ class ProfileParser {
     required String tempFilePath,
     CancelToken? cancelToken,
   }) => _downloadProfile(rp.url, tempFilePath, cancelToken).flatMap(
-    (remoteHeaders) =>
-        TaskEither.fromEither(
-          populateHeaders(content: File(tempFilePath).readAsStringSync(), remoteHeaders: remoteHeaders),
-        ).flatMap(
-          (populatedHeaders) => TaskEither.fromEither(
-            parse(
-              tempFilePath: tempFilePath,
-              profile: rp.copyWith(populatedHeaders: populatedHeaders),
-            ).flatMap((profEntity) => Either.tryCatch(() => profEntity.toUpdateEntry(), ProfileFailure.unexpected)),
-          ),
+    (remoteHeaders) {
+      final content = File(tempFilePath).readAsStringSync();
+      final resolvedUrl = resolveNewDomain(rp.url, content, remoteHeaders);
+      return TaskEither.fromEither(
+        populateHeaders(content: content, remoteHeaders: remoteHeaders),
+      ).flatMap(
+        (populatedHeaders) => TaskEither.fromEither(
+          parse(
+            tempFilePath: tempFilePath,
+            profile: rp.copyWith(url: resolvedUrl, populatedHeaders: populatedHeaders),
+          ).flatMap((profEntity) => Either.tryCatch(() => profEntity.toUpdateEntry(), ProfileFailure.unexpected)),
         ),
+      );
+    },
   );
 
   Either<ProfileFailure, ProfileEntriesCompanion> offlineUpdate({


### PR DESCRIPTION
When a subscription server's domain gets blocked, users currently need VPN access to refresh their profile. This change allows servers to signal a domain migration via a `new-domain` HTTP response header (or `#new-domain` line in the subscription body), so the app automatically updates the stored subscription URL on the next successful fetch — enabling future refreshes without VPN once the new domain is reachable.

- Add `ProfileParser.resolveNewDomain()` to extract `new-domain` from response headers or subscription body content and replace the host portion of the URL while preserving path, query, and fragment
- Apply domain resolution in both `addRemote()` and `updateRemote()` before the profile entity is constructed
- Persist the resolved URL on update by including `url` in `toUpdateEntry()` in `ProfileDataMapper`